### PR TITLE
chore: standardize Node version and update spell check dictionary

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+# Version of Node to use
+use-node-version=20.12.2

--- a/.spr.yml
+++ b/.spr.yml
@@ -1,0 +1,12 @@
+githubRepoOwner: carvierdotdev
+githubRepoName: prismic-nextjs
+githubHost: github.com
+githubRemote: origin
+githubBranch: main
+requireChecks: false
+requireApproval: false
+mergeMethod: merge
+mergeQueue: false
+forceFetchTags: false
+showPrTitlesInStack: true
+branchPushIndividually: false

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "cSpell.words": ["carvierdotdev", "github", "prismic"]
+  "cSpell.words": ["carvierdotdev", "github", "prismic", "SPR"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "cSpell.words": ["prismic"]
+  "cSpell.words": ["carvierdotdev", "github", "prismic"]
 }


### PR DESCRIPTION
- Set the Node.js version to 20.12.2 in the .npmrc to align with project requirements.
- Updated the VS Code spell check dictionary to include 'SPR' alongside existing terms.

commit-id:379c1d8a

---

**Stack**:
- chore: standardize Node version and update spell check dictionary #4 ⬅
- feat: configure SPR tool for stack-based PR management #3


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*